### PR TITLE
Add as unavailable: natura, va

### DIFF
--- a/public_domains.py
+++ b/public_domains.py
@@ -14,8 +14,12 @@ nltk.download('punkt', quiet=True)
 
 known_unavailable = ['smile', 'windows','active','amazon','apple','audible',
                      'bank','baseball','basketball','boots','case','drive',
-                     'fast','fire','fly','museum','natura','origins','post',
-                     'prime','silk','va','weather']
+                     'fast','fire','fly','museum','origins','post',
+                     'prime','silk','weather'] +
+                    ['arte', 'audi', 'dell', 'gallo', 'globo', 'infiniti',
+                     'natura', 'star', 'visa', 'viva', 'vivo', 'va', 'vana'] +
+                    # Might be upcoming
+                    ['data', 'latino', 'mobile']
 
 nic = whois.NICClient()
 

--- a/public_domains.py
+++ b/public_domains.py
@@ -14,8 +14,8 @@ nltk.download('punkt', quiet=True)
 
 known_unavailable = ['smile', 'windows','active','amazon','apple','audible',
                      'bank','baseball','basketball','boots','case','drive',
-                     'fast','fire','fly','museum','origins','post','prime',
-                     'silk','weather']
+                     'fast','fire','fly','museum','natura','origins','post',
+                     'prime','silk','va','weather']
 
 nic = whois.NICClient()
 


### PR DESCRIPTION
The Vatican is an unlikely user of this tool and "va" is a common word.

And ".natura eligibility policy only allows for Natura Cosméticos S.A., its affiliates and trademark licensees to register domains", so dear Leopardi, no thanks, we won't have any of your suggestions:

rugginosa.dellitala.natura
dellanimal.famiglia.natura
chiuso.pensier.natura
contra.lempia.natura