### PR TITLE
Catch Gutenberg errors

### DIFF
--- a/public_domains.py
+++ b/public_domains.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import nltk
 import time
 import tqdm
@@ -89,6 +90,8 @@ def get_hosts(input_text, quiet=False):
             md = ' '.join([l.strip() for l in f.readlines()])
     else:
         md = gutenberg(input_text)
+        if md is None:
+            sys.exit('No Gutenberg results for "%s"' % input_text)
 
     md_sents = nltk.tokenize.sent_tokenize(md)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt") as f:
 if __name__ == "__main__":
     setuptools.setup(
         name="public_domains",
-        version="0.0.6",
+        version="0.0.7",
         url="https://github.com/edsu/public_domains",
         author="Ed Summers",
         author_email="ehs@pobox.com",


### PR DESCRIPTION
If your Gutenberg query doens't return any results it would be useful to see that instead of a bizarro stack trace :)

```
public_domains "picture of dorian grey"
Traceback (most recent call last):
  File "/Users/edsummers/.pyenv/versions/3.10.1/bin/public_domains", line 8, in <module>
    sys.exit(main())
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/public_domains.py", line 64, in main
    hosts = get_hosts(args.text_file, args.quiet)
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/public_domains.py", line 92, in get_hosts
    md_sents = nltk.tokenize.sent_tokenize(md)
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/__init__.py", line 107, in sent_tokenize
    return tokenizer.tokenize(text)
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1276, in tokenize
    return list(self.sentences_from_text(text, realign_boundaries))
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1332, in sentences_from_text
    return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1332, in <listcomp>
    return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1322, in span_tokenize
    for sentence in slices:
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1421, in _realign_boundaries
    for sentence1, sentence2 in _pair_iter(slices):
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 318, in _pair_iter
    prev = next(iterator)
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1395, in _slices_from_text
    for match, context in self._match_potential_end_contexts(text):
  File "/Users/edsummers/.pyenv/versions/3.10.1/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1375, in _match_potential_end_contexts
    for match in reversed(list(self._lang_vars.period_context_re().finditer(text))):
TypeError: expected string or bytes-like object
```
